### PR TITLE
Aligned versions in package.json and plugin.xml

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-support-kotlin",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Cordova Android application development kotlin support.",
   "repository": {
     "type": "git",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="cordova-support-kotlin" version="1.1.0"
+<plugin id="cordova-support-kotlin" version="1.2.1"
         xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android">
     <platform name="android">


### PR DESCRIPTION
We have created plugin, that depends on cordova-support-kotlin#v1.2.0 and it caused the following issue:
When two platform are already added adding this plugin installs and registers version 1.1.0 for the first platform (as it is described in plugin.xml file) and then for the second platform it tries to install 1.2.0 (as it is in npm repository) then comparing 1.2.0 with current version (1.1.0) and fails with the error:
`Failed to install 'cordova-plugin-blu-sdk': CordovaError: Version of installed plugin: "cordova-support-kotlin@1.1.0" does not satisfy dependency plugin requirement "cordova-support-kotlin@^1.2.0". Try --force to use installed plugin as dependency.
    at /usr/local/lib/node_modules/cordova/node_modules/cordova-lib/src/plugman/install.js:544:43
    at process._tickCallback (internal/process/next_tick.js:68:7)`

Anyhow, versions should be consistent across the repos