### PR TITLE
xml2js should be in dependency, not in devDependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/kainonly/cordova-support-kotlin/issues"
   },
   "homepage": "https://github.com/kainonly/cordova-support-kotlin#readme",
-  "devDependencies": {
+  "dependencies": {
     "xml2js": "^0.4.19"
   }
 }


### PR DESCRIPTION
If cordova project don't contain the xml2js as a dependency, hook will not work as it will not found the xml2js in the node modules.